### PR TITLE
Update API to the version 2022-02-22

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,11 +221,13 @@ let pageId = Block.Identifier("{PAGE UUIDv4}")
 
 // append paragraph with styled text to a page.
 let blocks: [WriteBlock] = [
+    .heading1(["Heading 1"], color: .orange),
     .paragraph([
         "Lorem ipsum dolor sit amet, ",
         .init(string: "consectetur", annotations: .bold),
         " adipiscing elit."
     ]),
+    .heading2(["Heading 2"], color: .orangeBackground),
     .columnList(columns: [
         .column([
             .paragraph(["Column 1"])
@@ -233,7 +235,26 @@ let blocks: [WriteBlock] = [
         .column([
             .paragraph(["Column 2"])
         ])
-    ])
+    ]),
+    try! .table(
+        width: 2,
+        headers: [
+            ["Header 1"], ["Header 2"]
+        ],
+        rows: [
+            .row(
+                header: ["Row 1 header"],
+                cells: [
+                    ["Cell 1-1"], ["Cell 1-2"]
+                ]
+            ),
+            .row(
+                cells: [
+                    ["Cell 2-1"], ["Cell 2-2"]
+                ]
+            )
+        ]
+    )
 ]
 notion.blockAppend(blockId: pageId, children: blocks) {
     print($0)

--- a/Sources/NotionSwift/Models/Blocks/Block.swift
+++ b/Sources/NotionSwift/Models/Blocks/Block.swift
@@ -21,5 +21,7 @@ extension Block {
         case hasChildren = "has_children"
         case color
         case object
+        case createdBy = "created_by"
+        case lastEditedBy = "last_edited_by"
     }
 }

--- a/Sources/NotionSwift/Models/Blocks/Block.swift
+++ b/Sources/NotionSwift/Models/Blocks/Block.swift
@@ -19,6 +19,7 @@ extension Block {
         case createdTime = "created_time"
         case lastEditedTime = "last_edited_time"
         case hasChildren = "has_children"
+        case color
         case object
     }
 }

--- a/Sources/NotionSwift/Models/Blocks/BlockColor.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockColor.swift
@@ -1,0 +1,119 @@
+//
+//  Created by Wojciech Chojnacki on 17/04/2022.
+//
+import Foundation
+
+public enum BlockColor: Equatable {
+    case `default`
+    case gray
+    case brown
+    case orange
+    case yellow
+    case green
+    case blue
+    case purple
+    case pink
+    case red
+    case grayBackground
+    case brownBackground
+    case orangeBackground
+    case yellowBackground
+    case greenBackground
+    case blueBackground
+    case purpleBackground
+    case pinkBackground
+    case redBackground
+    case unknown(String)
+    
+    init?(_ rawValue: String) {
+        let cases: [Self] = [.default,
+                     .gray,
+                     .brown,
+                     .orange,
+                     .yellow,
+                     .green,
+                     .blue,
+                     .purple,
+                     .pink,
+                     .red,
+                     .grayBackground,
+                     .brownBackground,
+                     .orangeBackground,
+                     .yellowBackground,
+                     .greenBackground,
+                     .blueBackground,
+                     .purpleBackground,
+                     .pinkBackground,
+                     .redBackground
+        ]
+        let value = rawValue.lowercased().trimmingCharacters(in: CharacterSet.whitespaces)
+        guard let item = cases.first(where: { $0.rawValue == value }) else {
+            return nil
+        }
+        
+        self = item
+    }
+    
+    public var rawValue: String {
+        switch self {
+        case .default:
+            return "default"
+        case .gray:
+            return "gray"
+        case .brown:
+            return "brown"
+        case .orange:
+            return "orange"
+        case .yellow:
+            return "yellow"
+        case .green:
+            return "green"
+        case .blue:
+            return "blue"
+        case .purple:
+            return "purple"
+        case .pink:
+            return "pink"
+        case .red:
+            return "red"
+        case .grayBackground:
+            return "gray_background"
+        case .brownBackground:
+            return "brown_background"
+        case .orangeBackground:
+            return "orange_background"
+        case .yellowBackground:
+            return "yellow_background"
+        case .greenBackground:
+            return "green_background"
+        case .blueBackground:
+            return "blue_background"
+        case .purpleBackground:
+            return "purple_background"
+        case .pinkBackground:
+            return "pink_background"
+        case .redBackground:
+            return "red_background"
+        case .unknown(let value):
+            return value
+        }
+    }
+}
+
+extension BlockColor: Codable {
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let value = Self(rawValue) else {
+            self = .unknown(rawValue)
+            return
+        }
+        
+        self = value
+    }
+    
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+}

--- a/Sources/NotionSwift/Models/Blocks/BlockType+Builders.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType+Builders.swift
@@ -6,49 +6,57 @@ import Foundation
 
 public extension BlockType {
 
-    static func paragraph(_ richText: [RichText], children: [BlockType]? = nil) -> BlockType {
-        return .paragraph(.init(richText: richText, children: children))
+    static func paragraph(
+        _ richText: [RichText],
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
+    ) -> BlockType {
+        return .paragraph(.init(richText: richText, children: children, color: color))
     }
     
-    static func heading1(_ richText: [RichText]) -> Self {
-        return .heading1(.init(richText: richText))
+    static func heading1(_ richText: [RichText], color: BlockColor = .default) -> Self {
+        return .heading1(.init(richText: richText, color: color))
     }
 
-    static func heading2(_ richText: [RichText]) -> Self {
-        return .heading2(.init(richText: richText))
+    static func heading2(_ richText: [RichText], color: BlockColor = .default) -> Self {
+        return .heading2(.init(richText: richText, color: color))
     }
 
-    static func heading3(_ richText: [RichText]) -> Self {
-        return .heading3(.init(richText: richText))
+    static func heading3(_ richText: [RichText], color: BlockColor = .default) -> Self {
+        return .heading3(.init(richText: richText, color: color))
     }
 
     static func bulletedListItem(
         _ richText: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .bulletedListItem(.init(richText: richText, children: children))
+        return .bulletedListItem(.init(richText: richText, children: children, color: color))
     }
 
     static func numberedListItem(
         _ richText: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .numberedListItem(.init(richText: richText, children: children))
+        return .numberedListItem(.init(richText: richText, children: children, color: color))
     }
 
     static func toDo(
         _ richText: [RichText],
         checked: Bool? = nil,
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .toDo(.init(richText: richText, checked: checked, children: children))
+        return .toDo(.init(richText: richText, checked: checked, color: color, children: children))
     }
 
     static func toggle(
         _ richText: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .toggle(.init(richText: richText, children: children))
+        return .toggle(.init(richText: richText, children: children, color: color))
     }
 
     static func code(
@@ -73,16 +81,18 @@ public extension BlockType {
     static func callout(
         _ richText: [RichText],
         children: [BlockType]? = nil,
-        icon: IconFile? = nil
+        icon: IconFile? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .callout(.init(richText: richText, children: children, icon: icon))
+        return .callout(.init(richText: richText, children: children, icon: icon, color: color))
     }
 
     static func quote(
         _ richText: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        return .quote(.init(richText: richText, children: children))
+        return .quote(.init(richText: richText, children: children, color: color))
     }
 
     static func video(file: FileFile, caption: [RichText] = []) -> Self {

--- a/Sources/NotionSwift/Models/Blocks/BlockType+Builders.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType+Builders.swift
@@ -6,56 +6,56 @@ import Foundation
 
 public extension BlockType {
 
-    static func paragraph(_ text: [RichText], children: [BlockType]? = nil) -> BlockType {
-        return .paragraph(.init(text: text, children: children))
+    static func paragraph(_ richText: [RichText], children: [BlockType]? = nil) -> BlockType {
+        return .paragraph(.init(richText: richText, children: children))
     }
     
-    static func heading1(_ text: [RichText]) -> Self {
-        return .heading1(.init(text: text))
+    static func heading1(_ richText: [RichText]) -> Self {
+        return .heading1(.init(richText: richText))
     }
 
-    static func heading2(_ text: [RichText]) -> Self {
-        return .heading2(.init(text: text))
+    static func heading2(_ richText: [RichText]) -> Self {
+        return .heading2(.init(richText: richText))
     }
 
-    static func heading3(_ text: [RichText]) -> Self {
-        return .heading3(.init(text: text))
+    static func heading3(_ richText: [RichText]) -> Self {
+        return .heading3(.init(richText: richText))
     }
 
     static func bulletedListItem(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil
     ) -> Self {
-        return .bulletedListItem(.init(text: text, children: children))
+        return .bulletedListItem(.init(richText: richText, children: children))
     }
 
     static func numberedListItem(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil
     ) -> Self {
-        return .numberedListItem(.init(text: text, children: children))
+        return .numberedListItem(.init(richText: richText, children: children))
     }
 
     static func toDo(
-        _ text: [RichText],
+        _ richText: [RichText],
         checked: Bool? = nil,
         children: [BlockType]? = nil
     ) -> Self {
-        return .toDo(.init(text: text, checked: checked, children: children))
+        return .toDo(.init(richText: richText, checked: checked, children: children))
     }
 
     static func toggle(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil
     ) -> Self {
-        return .toggle(.init(text: text, children: children))
+        return .toggle(.init(richText: richText, children: children))
     }
 
     static func code(
-        _ text: [RichText],
+        _ richText: [RichText],
         language: String? = nil
     ) -> Self {
-        return .code(.init(text: text, language: language))
+        return .code(.init(richText: richText, language: language))
     }
 
     static func childPage(_ title: String) -> Self {
@@ -71,18 +71,18 @@ public extension BlockType {
     }
 
     static func callout(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil,
         icon: IconFile? = nil
     ) -> Self {
-        return .callout(.init(text: text, children: children, icon: icon))
+        return .callout(.init(richText: richText, children: children, icon: icon))
     }
 
     static func quote(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil
     ) -> Self {
-        return .quote(.init(text: text, children: children))
+        return .quote(.init(richText: richText, children: children))
     }
 
     static func video(file: FileFile, caption: [RichText] = []) -> Self {
@@ -114,9 +114,9 @@ public extension BlockType {
     }
     
     static func template(
-        _ text: [RichText],
+        _ richText: [RichText],
         children: [BlockType]? = nil
     ) -> Self {
-        return .template(.init(text: text, children: children))
+        return .template(.init(richText: richText, children: children))
     }
 }

--- a/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
@@ -257,6 +257,29 @@ public extension BlockType {
             self.children = children
         }
     }
+    
+    struct TableBlockValue {
+        public let tableWidth: Int
+        public let hasColumnHeader: Bool
+        public let hasRowHeader: Bool
+        // field used only for encoding for adding/appending new blocks
+        public let children: [BlockType]?
+        
+        public init(tableWidth: Int, hasColumnHeader: Bool, hasRowHeader: Bool, children: [BlockType]? = nil) {
+            self.tableWidth = tableWidth
+            self.hasColumnHeader = hasColumnHeader
+            self.hasRowHeader = hasRowHeader
+            self.children = children
+        }
+    }
+    
+    struct TableRowBlockValue {
+        public let cells: [[RichText]]
+        
+        public init(cells: [[RichText]]) {
+            self.cells = cells
+        }
+    }
 }
 
 // MARK: - Codable
@@ -410,3 +433,14 @@ extension BlockType.TemplateBlockValue: Codable {
         case children
     }
 }
+
+extension BlockType.TableBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case tableWidth = "table_width"
+        case hasColumnHeader = "has_column_header"
+        case hasRowHeader = "has_row_header"
+        case children
+    }
+}
+
+extension BlockType.TableRowBlockValue: Codable {}

--- a/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
@@ -18,32 +18,61 @@ public extension BlockType {
     }
 
     struct TextAndChildrenBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         /// field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
+        @available(*, deprecated, message: "Please use init(richText:children:) instead")
         public init(text: [RichText], children: [BlockType]? = nil) {
-            self.text = text
+            self.richText = text
+            self.children = children
+        }
+        
+        public init(richText: [RichText], children: [BlockType]? = nil) {
+            self.richText = richText
             self.children = children
         }
     }
 
     struct HeadingBlockValue {
-        public let text: [RichText]
-
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
+        @available(*, deprecated, message: "Please use init(richText:) instead")
         public init(text: [RichText]) {
-            self.text = text
+            self.richText = text
+        }
+        
+        public init(richText: [RichText]) {
+            self.richText = richText
         }
     }
 
     struct ToDoBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         public let checked: Bool?
         // field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
+        @available(*, deprecated, message: "Please use init(richText:checked:children:) instead")
         public init(text: [RichText], checked: Bool? = nil, children: [BlockType]? = nil) {
-            self.text = text
+            self.richText = text
+            self.checked = checked
+            self.children = children
+        }
+        
+        public init(richText: [RichText], checked: Bool? = nil, children: [BlockType]? = nil) {
+            self.richText = richText
             self.checked = checked
             self.children = children
         }
@@ -66,35 +95,66 @@ public extension BlockType {
     }
 
     struct CodeBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         public let language: String?
 
+        @available(*, deprecated, message: "Please use init(richText:language) instead")
         public init(text: [RichText], language: String? = nil) {
-            self.text = text
+            self.richText = text
+            self.language = language
+        }
+        
+        public init(richText: [RichText], language: String? = nil) {
+            self.richText = richText
             self.language = language
         }
     }
 
     struct CalloutBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         // field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
         public let icon: IconFile?
 
+        @available(*, deprecated, message: "Please use init(richText:children:icon:) instead")
         public init(text: [RichText], children: [BlockType]? = nil, icon: IconFile? = nil) {
-            self.text = text
+            self.richText = text
+            self.children = children
+            self.icon = icon
+        }
+        
+        public init(richText: [RichText], children: [BlockType]? = nil, icon: IconFile? = nil) {
+            self.richText = richText
             self.children = children
             self.icon = icon
         }
     }
 
     struct QuoteBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         // field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
+        @available(*, deprecated, message: "Please use init(richText:children:) instead")
         public init(text: [RichText], children: [BlockType]? = nil) {
-            self.text = text
+            self.richText = text
+            self.children = children
+        }
+        
+        public init(richText: [RichText], children: [BlockType]? = nil) {
+            self.richText = richText
             self.children = children
         }
     }
@@ -149,12 +209,22 @@ public extension BlockType {
     }
 
     struct TemplateBlockValue {
-        public let text: [RichText]
+        public let richText: [RichText]
+        @available(*, deprecated, renamed: "richText")
+        public var text: [RichText] {
+            richText
+        }
         /// field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
+        @available(*, deprecated, message: "Please use init(richText:children:) instead")
         public init(text: [RichText], children: [BlockType]? = nil) {
-            self.text = text
+            self.richText = text
+            self.children = children
+        }
+        
+        public init(richText: [RichText], children: [BlockType]? = nil) {
+            self.richText = richText
             self.children = children
         }
     }
@@ -163,18 +233,53 @@ public extension BlockType {
 // MARK: - Codable
 
 extension BlockType.ChildrenBlockValue: Codable {}
-extension BlockType.TextAndChildrenBlockValue: Codable {}
-extension BlockType.HeadingBlockValue: Codable {}
-extension BlockType.ToDoBlockValue: Codable {}
+
+extension BlockType.TextAndChildrenBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case children
+    }
+}
+extension BlockType.HeadingBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+    }
+}
+extension BlockType.ToDoBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case checked
+        case children
+    }
+}
+
 extension BlockType.ChildPageBlockValue: Codable {}
+
 extension BlockType.ChildDatabaseBlockValue: Codable {}
+
+extension BlockType.CodeBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case language
+    }
+}
+extension BlockType.CalloutBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case children
+        case icon
+    }
+}
+extension BlockType.QuoteBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case children
+    }
+}
+
 extension BlockType.EmbedBlockValue: Codable {}
-extension BlockType.CalloutBlockValue: Codable {}
-extension BlockType.CodeBlockValue: Codable {}
-extension BlockType.QuoteBlockValue: Codable {}
+
 extension BlockType.BookmarkBlockValue: Codable {}
-extension BlockType.EquationBlockValue: Codable {}
-extension BlockType.TemplateBlockValue: Codable {}
 
 extension BlockType.FileBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
@@ -193,6 +298,8 @@ extension BlockType.FileBlockValue: Codable {
         try file.encode(to: encoder)
     }
 }
+
+extension BlockType.EquationBlockValue: Codable {}
 
 extension BlockType.LinkToPageBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
@@ -258,5 +365,12 @@ extension BlockType.SyncedBlockValue: Codable {
         case .originalBlock:
             try container.encode(Optional<_ReferenceValue>.none, forKey: .syncedFrom)
         }
+    }
+}
+
+extension BlockType.TemplateBlockValue: Codable {
+    enum CodingKeys: String, CodingKey {
+        case richText = "rich_text"
+        case children
     }
 }

--- a/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType+Values.swift
@@ -23,6 +23,8 @@ public extension BlockType {
         public var text: [RichText] {
             richText
         }
+        public let color: BlockColor
+        
         /// field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
@@ -30,11 +32,17 @@ public extension BlockType {
         public init(text: [RichText], children: [BlockType]? = nil) {
             self.richText = text
             self.children = children
+            self.color = .default
         }
         
-        public init(richText: [RichText], children: [BlockType]? = nil) {
+        public init(
+            richText: [RichText],
+            children: [BlockType]? = nil,
+            color: BlockColor
+        ) {
             self.richText = richText
             self.children = children
+            self.color = color
         }
     }
 
@@ -44,13 +52,17 @@ public extension BlockType {
         public var text: [RichText] {
             richText
         }
-        @available(*, deprecated, message: "Please use init(richText:) instead")
+        public let color: BlockColor
+        
+        @available(*, deprecated, message: "Please use init(richText:color:) instead")
         public init(text: [RichText]) {
             self.richText = text
+            self.color = .default
         }
         
-        public init(richText: [RichText]) {
+        public init(richText: [RichText], color: BlockColor) {
             self.richText = richText
+            self.color = color
         }
     }
 
@@ -61,19 +73,22 @@ public extension BlockType {
             richText
         }
         public let checked: Bool?
+        public let color: BlockColor
         // field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
 
-        @available(*, deprecated, message: "Please use init(richText:checked:children:) instead")
+        @available(*, deprecated, message: "Please use init(richText:checked:color:children:) instead")
         public init(text: [RichText], checked: Bool? = nil, children: [BlockType]? = nil) {
             self.richText = text
             self.checked = checked
+            self.color = .default
             self.children = children
         }
         
-        public init(richText: [RichText], checked: Bool? = nil, children: [BlockType]? = nil) {
+        public init(richText: [RichText], checked: Bool? = nil, color: BlockColor, children: [BlockType]? = nil) {
             self.richText = richText
             self.checked = checked
+            self.color = color
             self.children = children
         }
     }
@@ -123,23 +138,27 @@ public extension BlockType {
         // field used only for encoding for adding/appending new blocks
         public let children: [BlockType]?
         public let icon: IconFile?
-
+        public let color: BlockColor
+        
         @available(*, deprecated, message: "Please use init(richText:children:icon:) instead")
         public init(text: [RichText], children: [BlockType]? = nil, icon: IconFile? = nil) {
             self.richText = text
             self.children = children
             self.icon = icon
+            self.color = .default
         }
         
-        public init(richText: [RichText], children: [BlockType]? = nil, icon: IconFile? = nil) {
+        public init(richText: [RichText], children: [BlockType]? = nil, icon: IconFile? = nil, color: BlockColor) {
             self.richText = richText
             self.children = children
             self.icon = icon
+            self.color = color
         }
     }
 
     struct QuoteBlockValue {
         public let richText: [RichText]
+        public let color: BlockColor
         @available(*, deprecated, renamed: "richText")
         public var text: [RichText] {
             richText
@@ -151,11 +170,13 @@ public extension BlockType {
         public init(text: [RichText], children: [BlockType]? = nil) {
             self.richText = text
             self.children = children
+            self.color = .default
         }
         
-        public init(richText: [RichText], children: [BlockType]? = nil) {
+        public init(richText: [RichText], children: [BlockType]? = nil, color: BlockColor) {
             self.richText = richText
             self.children = children
+            self.color = color
         }
     }
 
@@ -197,6 +218,14 @@ public extension BlockType {
         }
     }
 
+    struct TableOfContentsBlockValue {
+        public let color: BlockColor
+        
+        public init(color: BlockColor) {
+            self.color = color
+        }
+    }
+    
     enum LinkToPageBlockValue {
         case page(Page.Identifier)
         case database(Database.Identifier)
@@ -238,17 +267,20 @@ extension BlockType.TextAndChildrenBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
         case richText = "rich_text"
         case children
+        case color
     }
 }
 extension BlockType.HeadingBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
         case richText = "rich_text"
+        case color
     }
 }
 extension BlockType.ToDoBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
         case richText = "rich_text"
         case checked
+        case color
         case children
     }
 }
@@ -268,11 +300,13 @@ extension BlockType.CalloutBlockValue: Codable {
         case richText = "rich_text"
         case children
         case icon
+        case color
     }
 }
 extension BlockType.QuoteBlockValue: Codable {
     enum CodingKeys: String, CodingKey {
         case richText = "rich_text"
+        case color
         case children
     }
 }
@@ -300,6 +334,8 @@ extension BlockType.FileBlockValue: Codable {
 }
 
 extension BlockType.EquationBlockValue: Codable {}
+
+extension BlockType.TableOfContentsBlockValue: Codable {}
 
 extension BlockType.LinkToPageBlockValue: Codable {
     enum CodingKeys: String, CodingKey {

--- a/Sources/NotionSwift/Models/Blocks/BlockType.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType.swift
@@ -27,7 +27,7 @@ public enum BlockType {
     case bookmark(BookmarkBlockValue)
     case equation(EquationBlockValue)
     case divider
-    case tableOfContents
+    case tableOfContents(TableOfContentsBlockValue)
     case breadcrumb
     case column(ChildrenBlockValue)
     case columnList(ChildrenBlockValue)
@@ -216,7 +216,8 @@ extension BlockType: Codable {
         case .divider:
             self = .divider
         case .tableOfContents:
-            self = .tableOfContents
+            let value = try container.decode(TableOfContentsBlockValue.self, forKey: key)
+            self = .tableOfContents(value)
         case .breadcrumb:
             self = .breadcrumb
         case .column:

--- a/Sources/NotionSwift/Models/Blocks/BlockType.swift
+++ b/Sources/NotionSwift/Models/Blocks/BlockType.swift
@@ -34,6 +34,8 @@ public enum BlockType {
     case linkToPage(LinkToPageBlockValue)
     case syncedBlock(SyncedBlockValue)
     case template(TemplateBlockValue)
+    case table(TableBlockValue)
+    case tableRow(TableRowBlockValue)
     case unsupported(type: String)
 }
 
@@ -71,6 +73,8 @@ extension BlockType: Codable {
         case linkToPage = "link_to_page"
         case syncedBlock = "synced_block"
         case template
+        case table
+        case tableRow = "table_row"
         case unsupported
     }
 
@@ -136,6 +140,10 @@ extension BlockType: Codable {
             return .syncedBlock
         case .template:
             return .template
+        case .table:
+            return .table
+        case .tableRow:
+            return .tableRow
         }
     }
 
@@ -235,6 +243,12 @@ extension BlockType: Codable {
         case .template:
             let value = try container.decode(TemplateBlockValue.self, forKey: key)
             self = .template(value)
+        case .table:
+            let value = try container.decode(TableBlockValue.self, forKey: key)
+            self = .table(value)
+        case .tableRow:
+            let value = try container.decode(TableRowBlockValue.self, forKey: key)
+            self = .tableRow(value)
         case .type, .unsupported:
             self = .unsupported(type: type)
         }
@@ -298,9 +312,14 @@ extension BlockType: Codable {
             try container.encode(value, forKey: key)
         case .column(let value):
             try container.encode(value, forKey: key)
-        case .divider, .tableOfContents, .breadcrumb:
+        case .tableOfContents(let value):
+            try container.encode(value, forKey: key)
+        case .table(let value):
+            try container.encode(value, forKey: key)
+        case .tableRow(let value):
+            try container.encode(value, forKey: key)
+        case .divider, .breadcrumb:
             try container.encode([String: String](), forKey: key)
-            break
         case .unsupported:
             break
         }

--- a/Sources/NotionSwift/Models/Blocks/ReadBlock.swift
+++ b/Sources/NotionSwift/Models/Blocks/ReadBlock.swift
@@ -12,6 +12,8 @@ public struct ReadBlock: CustomStringConvertible {
     public let archived: Bool
     public let type: BlockType
     public let hasChildren: Bool
+    public let createdBy: PartialUser
+    public let lastEditedBy: PartialUser
     /// Notion API doesn't directly provide block children. To load blok's children use `NotionClient.blockChildren` method
     /// and create a new instance of this struct using `.updateChildren(_)` method.
     public let children: [ReadBlock]
@@ -23,6 +25,8 @@ public struct ReadBlock: CustomStringConvertible {
         createdTime: Date,
         lastEditedTime: Date,
         hasChildren: Bool,
+        createdBy: PartialUser,
+        lastEditedBy: PartialUser,
         children: [ReadBlock] = []
     ) {
         self.id = id
@@ -31,6 +35,8 @@ public struct ReadBlock: CustomStringConvertible {
         self.lastEditedTime = lastEditedTime
         self.type = type
         self.hasChildren = hasChildren
+        self.createdBy = createdBy
+        self.lastEditedBy = lastEditedBy
         self.children = children
     }
 
@@ -46,6 +52,8 @@ public struct ReadBlock: CustomStringConvertible {
             createdTime: self.createdTime,
             lastEditedTime: self.lastEditedTime,
             hasChildren: self.hasChildren,
+            createdBy: self.createdBy,
+            lastEditedBy: self.lastEditedBy,
             children: children
         )
     }
@@ -60,6 +68,8 @@ extension ReadBlock: Decodable {
         archived = try container.decode(Bool.self, forKey: .archived)
         createdTime = try container.decode(Date.self, forKey: .createdTime)
         lastEditedTime = try container.decode(Date.self, forKey: .lastEditedTime)
+        createdBy = try container.decode(PartialUser.self, forKey: .createdBy)
+        lastEditedBy = try container.decode(PartialUser.self, forKey: .lastEditedBy)
         type = try BlockType(from: decoder)
         hasChildren = try container.decode(Bool.self, forKey: .hasChildren)
         children = []

--- a/Sources/NotionSwift/Models/Blocks/UpdateBlock.swift
+++ b/Sources/NotionSwift/Models/Blocks/UpdateBlock.swift
@@ -7,10 +7,12 @@ import Foundation
 public struct UpdateBlock {
     public let value: BlockType?
     public let archived: Bool?
+    public let color: BlockColor
 
-    public init(value: BlockType?, archived: Bool? = nil) {
+    public init(value: BlockType?, archived: Bool? = nil, color: BlockColor = .default) {
         self.value = value
         self.archived = archived
+        self.color = color
     }
 }
 
@@ -23,6 +25,7 @@ extension UpdateBlock: Encodable {
             try value.encode(to: encoder)
         }
         try container.encodeIfPresent(archived, forKey: .archived)
+        try container.encode(color, forKey: .color)
     }
 }
 

--- a/Sources/NotionSwift/Models/Blocks/WriteBlock+Builders.swift
+++ b/Sources/NotionSwift/Models/Blocks/WriteBlock+Builders.swift
@@ -15,47 +15,52 @@ public extension WriteBlock {
     
     static func paragraph(
         _ text: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .paragraph(text, children: children))
+        .init(type: .paragraph(text, children: children, color: color))
     }
     
-    static func heading1(_ text: [RichText]) -> Self {
-        .init(type: .heading1(text))
+    static func heading1(_ text: [RichText], color: BlockColor = .default) -> Self {
+        .init(type: .heading1(text, color: color))
     }
     
-    static func heading2(_ text: [RichText]) -> Self {
-        .init(type: .heading2(text))
+    static func heading2(_ text: [RichText], color: BlockColor = .default) -> Self {
+        .init(type: .heading2(text, color: color))
     }
     
-    static func heading3(_ text: [RichText]) -> Self {
-        .init(type: .heading3(text))
+    static func heading3(_ text: [RichText], color: BlockColor = .default) -> Self {
+        .init(type: .heading3(text, color: color))
     }
     
     static func bulletedListItem(
         _ text: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .bulletedListItem(text, children: children))
+        .init(type: .bulletedListItem(text, children: children, color: color))
     }
     static func numberedListItem(
         _ text: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .numberedListItem(text, children: children))
+        .init(type: .numberedListItem(text, children: children, color: color))
     }
     static func toDo(
         _ text: [RichText],
         children: [BlockType]? = nil,
-        checked: Bool = false
+        checked: Bool = false,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .toDo(text, checked: checked, children: children))
+        .init(type: .toDo(text, checked: checked, children: children, color: color))
     }
     static func toggle(
         _ text: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .toggle(text, children: children))
+        .init(type: .toggle(text, children: children, color: color))
     }
     static func code(
         _ text: [RichText],
@@ -74,16 +79,18 @@ public extension WriteBlock {
     static func callout(
         _ text: [RichText],
         children: [BlockType]? = nil,
-        icon: IconFile? = nil
+        icon: IconFile? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .callout(text, children: children, icon: icon))
+        .init(type: .callout(text, children: children, icon: icon, color: color))
     }
     
     static func quote(
         _ text: [RichText],
-        children: [BlockType]? = nil
+        children: [BlockType]? = nil,
+        color: BlockColor = .default
     ) -> Self {
-        .init(type: .quote(text, children: children))
+        .init(type: .quote(text, children: children, color: color))
     }
     
     static func video(
@@ -136,8 +143,8 @@ public extension WriteBlock {
         .init(type: .divider)
     }
     
-    static func tableOfContents() -> Self {
-        .init(type: .tableOfContents)
+    static func tableOfContents(color: BlockColor = .default) -> Self {
+        .init(type: .tableOfContents(.init(color: color)))
     }
     
     static func breadcrumb() -> Self {

--- a/Sources/NotionSwift/Models/Database.swift
+++ b/Sources/NotionSwift/Models/Database.swift
@@ -14,6 +14,8 @@ public struct Database {
     public let cover: CoverFile?
     public let createdTime: Date
     public let lastEditedTime: Date
+    public let createdBy: PartialUser
+    public let lastEditedBy: PartialUser
     public let properties: [PropertyName: DatabaseProperty]
     public let parent: DatabaseParent
 
@@ -25,6 +27,8 @@ public struct Database {
         cover: CoverFile?,
         createdTime: Date,
         lastEditedTime: Date,
+        createdBy: PartialUser,
+        lastEditedBy: PartialUser,
         properties: [Database.PropertyName: DatabaseProperty],
         parent: DatabaseParent
     ) {
@@ -35,6 +39,8 @@ public struct Database {
         self.cover = cover
         self.createdTime = createdTime
         self.lastEditedTime = lastEditedTime
+        self.createdBy = createdBy
+        self.lastEditedBy = lastEditedBy
         self.properties = properties
         self.parent = parent
     }
@@ -49,6 +55,8 @@ extension Database: Decodable {
         case cover
         case createdTime = "created_time"
         case lastEditedTime = "last_edited_time"
+        case createdBy = "created_by"
+        case lastEditedBy = "last_edited_by"
         case properties
         case parent
     }

--- a/Sources/NotionSwift/Models/Page.swift
+++ b/Sources/NotionSwift/Models/Page.swift
@@ -11,6 +11,8 @@ public struct Page {
     public let id: Identifier
     public let createdTime: Date
     public let lastEditedTime: Date
+    public let createdBy: PartialUser
+    public let lastEditedBy: PartialUser
     public let icon: IconFile?
     public let cover: CoverFile?
     public let parent: PageParentType
@@ -21,6 +23,8 @@ public struct Page {
         id: Identifier,
         createdTime: Date,
         lastEditedTime: Date,
+        createdBy: PartialUser,
+        lastEditedBy: PartialUser,
         icon: IconFile?,
         cover: CoverFile?,
         parent: PageParentType,
@@ -30,6 +34,8 @@ public struct Page {
         self.id = id
         self.createdTime = createdTime
         self.lastEditedTime = lastEditedTime
+        self.createdBy = createdBy
+        self.lastEditedBy = lastEditedBy
         self.icon = icon
         self.cover = cover
         self.parent = parent
@@ -42,7 +48,9 @@ extension Page: Decodable {
     enum CodingKeys: String, CodingKey {
         case id
         case createdTime = "created_time"
-        case lastEditedTime = "last_edited_time"
+        case lastEditedTime = "last_edited_time"        
+        case createdBy = "created_by"
+        case lastEditedBy = "last_edited_by"
         case icon
         case cover
         case archived

--- a/Sources/NotionSwift/Models/PartialUser.swift
+++ b/Sources/NotionSwift/Models/PartialUser.swift
@@ -1,0 +1,18 @@
+//
+//  Created by Wojciech Chojnacki on 17/04/2022.
+//
+
+import Foundation
+
+public struct PartialUser {
+    public let id: User.Identifier
+    
+    public init(id: User.Identifier) {
+        self.id = id
+    }
+}
+
+extension PartialUser: Codable {}
+
+@available(iOS 13.0, *)
+extension PartialUser: Identifiable {}

--- a/Sources/NotionSwift/Models/Request/Filter/DatabasePropertyFilter+Encodable.swift
+++ b/Sources/NotionSwift/Models/Request/Filter/DatabasePropertyFilter+Encodable.swift
@@ -10,7 +10,7 @@ extension DatabasePropertyFilter: Encodable {
         case richText = "rich_text"
         case url
         case email
-        case phone
+        case phoneNumber = "phone_number"
         case number
         case checkbox
         case select
@@ -40,8 +40,8 @@ extension DatabasePropertyFilter: Encodable {
             try container.encode(contition, forKey: .url)
         case .email(let contition):
             try container.encode(contition, forKey: .email)
-        case .phone(let contition):
-            try container.encode(contition, forKey: .phone)
+        case .phoneNumber(let contition):
+            try container.encode(contition, forKey: .phoneNumber)
         case .number(let contition):
             try container.encode(contition, forKey: .number)
         case .checkbox(let contition):
@@ -142,7 +142,7 @@ extension DatabasePropertyFilter.DateCondition: Encodable {
 
 extension DatabasePropertyFilter.FormulaCondition: Encodable {
     enum CodingKeys: String, CodingKey {
-        case text
+        case string
         case checkbox
         case number
         case date
@@ -151,8 +151,8 @@ extension DatabasePropertyFilter.FormulaCondition: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         switch self {
-        case .text(let value):
-            try container.encode(value, forKey: .text)
+        case .string(let value):
+            try container.encode(value, forKey: .string)
         case .checkbox(let value):
             try container.encode(value, forKey: .checkbox)
         case .number(let value):

--- a/Sources/NotionSwift/Models/Request/Filter/DatabasePropertyFilter.swift
+++ b/Sources/NotionSwift/Models/Request/Filter/DatabasePropertyFilter.swift
@@ -15,7 +15,7 @@ extension DatabasePropertyFilter {
         case richText(TextCondition)
         case url(TextCondition)
         case email(TextCondition)
-        case phone(TextCondition)
+        case phoneNumber(TextCondition)
         case number(NumberCondition)
         case checkbox(CheckboxCondition)
         case select(SimpleGenericCondition<String>)
@@ -34,7 +34,7 @@ extension DatabasePropertyFilter {
 
 extension DatabasePropertyFilter {
     public enum FormulaCondition {
-        case text(TextCondition)
+        case string(TextCondition)
         case checkbox(CheckboxCondition)
         case number(NumberCondition)
         case date(DateCondition)

--- a/Sources/NotionSwift/Models/Responses/SearchResponse.swift
+++ b/Sources/NotionSwift/Models/Responses/SearchResponse.swift
@@ -8,6 +8,20 @@ public enum SearchResultItem {
     case page(Page)
     case database(Database)
     case unknown
+    
+    public var database: Database? {
+        guard case .database(let value) = self else {
+            return nil
+        }
+        return value
+    }
+    
+    public var page: Page? {
+        guard case .page(let value) = self else {
+            return nil
+        }
+        return value
+    }
 }
 
 extension SearchResultItem: Decodable {

--- a/Sources/NotionSwift/NotionClient.swift
+++ b/Sources/NotionSwift/NotionClient.swift
@@ -8,7 +8,7 @@ public final class NotionClient: NotionClientType {
     private let accessKeyProvider: AccessKeyProvider
     let networkClient: NetworkClient
 
-    private let APIVersion = "2021-08-16"
+    private let APIVersion = "2022-02-22"
     let urlBuilder = URLBuilder()
 
     public init(

--- a/Sources/NotionSwift/NotionClientError.swift
+++ b/Sources/NotionSwift/NotionClientError.swift
@@ -10,6 +10,7 @@ public enum NotionClientError: Error {
     case bodyEncodingError(Error)
     case decodingError(Error)
     case unsupportedResponseError
+    case builderError(message: String)
 }
 
 public enum NotionErrorCode: String {

--- a/Tests/NotionSwiftTests/Helpers.swift
+++ b/Tests/NotionSwiftTests/Helpers.swift
@@ -13,6 +13,12 @@ func encodeToJson<T: Encodable>(_ entity: T) throws -> String {
     return String(data: data, encoding: .utf8)!
 }
 
+func decodeFromJson<T: Decodable>(_ entity: String) throws -> T {
+    let decoder = JSONDecoder()
+    let data = try decoder.decode(T.self, from: entity.data(using: .utf8)!)
+    return data
+}
+
 func buildDayDate(day: Int, month: Int, year: Int) -> Date {
     var c = DateComponents()
     c.setValue(day, for: .day)

--- a/Tests/NotionSwiftTests/Models/BlockColorTests.swift
+++ b/Tests/NotionSwiftTests/Models/BlockColorTests.swift
@@ -1,0 +1,40 @@
+//
+//  Created by Wojciech Chojnacki on 17/04/2022.
+//
+
+import XCTest
+@testable import NotionSwift
+
+final class BlockColorTest: XCTestCase {
+    func testEncodeValue() throws {
+        let underTest = BlockColor.brownBackground
+
+        let result = try encodeToJson(underTest)
+
+        XCTAssertEqual(result, "\"brown_background\"")
+    }
+    
+    func testEncodeUnknownValue() throws {
+        let underTest = BlockColor.unknown("some_color")
+
+        let result = try encodeToJson(underTest)
+
+        XCTAssertEqual(result, "\"some_color\"")
+    }
+    
+    func testDecodeValue() throws {
+        let underTest = "\"brown_background\""
+
+        let result: BlockColor = try decodeFromJson(underTest)
+
+        XCTAssertEqual(result, BlockColor.brownBackground)
+    }
+    
+    func testDecodeUnknownValue() throws {
+        let underTest = "\"something\""
+
+        let result: BlockColor = try decodeFromJson(underTest)
+
+        XCTAssertEqual(result, BlockColor.unknown("something"))
+    }
+}

--- a/Tests/NotionSwiftTests/Request/PageCreateRequestTests.swift
+++ b/Tests/NotionSwiftTests/Request/PageCreateRequestTests.swift
@@ -25,19 +25,17 @@ final class PageCreateRequestTests: XCTestCase {
     func test_propertiesAndChildrenEncoding_case01() throws {
         let parentId = Page.Identifier("12345")
         let children: [WriteBlock] = [
-            .init(type: .paragraph(.init(text: [
-                .init(string: "Lorem ipsum dolor sit amet, ")
-            ])))
+            .paragraph(["Lorem ipsum dolor sit amet, "], color: .default)
         ]
         let given = PageCreateRequest(
             parent: .page(parentId),
-            properties: ["title": .init(type: .title([.init(string: "Lorem ipsum")]))],
+            properties: ["title": .init(type: .title(["Lorem ipsum"]))],
             children: children
         )
 
         let result = try encodeToJson(given)
 
-        XCTAssertEqual(result, #"{"children":[{"object":"block","paragraph":{"text":[{"text":{"content":"Lorem ipsum dolor sit amet, "}}]},"type":"paragraph"}],"parent":{"page_id":"12345"},"properties":{"title":{"title":[{"text":{"content":"Lorem ipsum"}}]}}}"#)
+        XCTAssertEqual(result, #"{"children":[{"object":"block","paragraph":{"color":"default","rich_text":[{"text":{"content":"Lorem ipsum dolor sit amet, "}}]},"type":"paragraph"}],"parent":{"page_id":"12345"},"properties":{"title":{"title":[{"text":{"content":"Lorem ipsum"}}]}}}"#)
     }
 
     func test_childrenEncoding_case01() throws {
@@ -54,7 +52,7 @@ final class PageCreateRequestTests: XCTestCase {
 
         let result = try encodeToJson(given)
 
-        XCTAssertEqual(result, #"{"children":[{"object":"block","paragraph":{"text":[{"text":{"content":"Lorem ipsum dolor sit amet, "}}]},"type":"paragraph"}],"parent":{"page_id":"12345"},"properties":{}}"#)
+        XCTAssertEqual(result, #"{"children":[{"object":"block","paragraph":{"color":"default","rich_text":[{"text":{"content":"Lorem ipsum dolor sit amet, "}}]},"type":"paragraph"}],"parent":{"page_id":"12345"},"properties":{}}"#)
     }
     
     func test_childrenEncoding_case02() throws {
@@ -62,10 +60,10 @@ final class PageCreateRequestTests: XCTestCase {
         let children: [WriteBlock] = [
             .columnList(columns: [
                 .column([
-                    .paragraph(["Column 1"])
+                    .paragraph(["Column 1"], color: .yellow)
                 ]),
                 .column([
-                    .paragraph(["Column 2"])
+                    .paragraph(["Column 2"], color: .green)
                 ])
             ])
         ]
@@ -78,6 +76,6 @@ final class PageCreateRequestTests: XCTestCase {
 
         let result = try encodeToJson(given)
 
-        XCTAssertEqual(result, #"{"children":[{"column_list":{"children":[{"column":{"children":[{"paragraph":{"text":[{"text":{"content":"Column 1"}}]},"type":"paragraph"}]},"type":"column"},{"column":{"children":[{"paragraph":{"text":[{"text":{"content":"Column 2"}}]},"type":"paragraph"}]},"type":"column"}]},"object":"block","type":"column_list"}],"parent":{"page_id":"12345"},"properties":{}}"#)
+        XCTAssertEqual(result, #"{"children":[{"column_list":{"children":[{"column":{"children":[{"paragraph":{"color":"yellow","rich_text":[{"text":{"content":"Column 1"}}]},"type":"paragraph"}]},"type":"column"},{"column":{"children":[{"paragraph":{"color":"green","rich_text":[{"text":{"content":"Column 2"}}]},"type":"paragraph"}]},"type":"column"}]},"object":"block","type":"column_list"}],"parent":{"page_id":"12345"},"properties":{}}"#)
     }
 }


### PR DESCRIPTION
* Update code to support API in version 2022-02-22
   * Rename `text` property to `richText` and deprecate old property name usages.
   * Changes in filter property names.
* Add support for color property in blocks 
* Add support for`lastEditedBy` & `createdBy` in pages, database & blocks
* Add support for `table` & `table_row` blocks with nice interface for creating it programaticly 