### PR TITLE
Fix wrong encoding for "relation" property type

### DIFF
--- a/Sources/NotionSwift/Models/PageProperty.swift
+++ b/Sources/NotionSwift/Models/PageProperty.swift
@@ -153,7 +153,7 @@ extension PagePropertyType: Codable {
         case type
     }
     
-    private struct PageRelation: Decodable {
+    private struct PageRelation: Codable {
         let id: Page.Identifier
     }
 
@@ -297,7 +297,7 @@ extension PagePropertyType: Codable {
         case .formula(let value):
             try container.encode(value, forKey: .formula)
         case .relation(let value):
-            try container.encode(value, forKey: .relation)
+            try container.encode(value.map(PageRelation.init(id:)), forKey: .relation)
         case .rollup(let value):
             try container.encode(value, forKey: .rollup)
         case .title(let value):

--- a/Sources/NotionSwift/Models/PageProperty.swift
+++ b/Sources/NotionSwift/Models/PageProperty.swift
@@ -106,7 +106,7 @@ extension PagePropertyType {
     public enum RollupPropertyValue {
         case array([PagePropertyType])
         case number(Int)
-        case date(DateRange)
+        case date(DateRange?)
         case unknown
     }
 }
@@ -453,7 +453,7 @@ extension PagePropertyType.RollupPropertyValue: Codable {
             let value = try container.decode(Int.self, forKey: .number)
             self = .number(value)
         case CodingKeys.date.rawValue:
-            let value = try container.decode(DateRange.self, forKey: .date)
+            let value = try container.decodeIfPresent(DateRange.self, forKey: .date)
             self = .date(value)
         default:
             self = .unknown


### PR DESCRIPTION
- Fixing issue #24 
- Fixing  Rollup property decoding error (data value can be null)