### PR TITLE
Included Name property in DatabaseProperty type

### DIFF
--- a/Sources/NotionSwift/Models/DatabaseProperty.swift
+++ b/Sources/NotionSwift/Models/DatabaseProperty.swift
@@ -7,13 +7,16 @@ import Foundation
 public struct DatabaseProperty {
     public typealias Identifier = EntityIdentifier<DatabaseProperty, String>
     public let id: Identifier
+    public let name: String
     public let type: DatabasePropertyType
 
     public init(
         id: DatabaseProperty.Identifier,
+        name: String,
         type: DatabasePropertyType
     ) {
         self.id = id
+        self.name = name
         self.type = type
     }
 }
@@ -21,11 +24,13 @@ public struct DatabaseProperty {
 extension DatabaseProperty: Decodable {
     enum CodingKeys: String, CodingKey {
         case id
+        case name
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(Identifier.self, forKey: .id)
+        self.name = try container.decode(String.self, forKey: .name)
         self.type = try DatabasePropertyType(from: decoder)
     }
 }


### PR DESCRIPTION
Hey, thanks a lot for creating and maintaining this package 💫

I've noticed that DatabaseProperty model does not contain the name field, even though it is returned from the API (https://developers.notion.com/changelog/database-property-objects-now-include-property-name). I've tested it quickly and it seems to work fine, name is deserialised and looks exactly like in Notion.