### PR TITLE
Fixed corrupted url deserialisation, added a way to sort by timestamp only

### DIFF
--- a/Sources/NotionSwift/Models/PageProperty.swift
+++ b/Sources/NotionSwift/Models/PageProperty.swift
@@ -239,8 +239,9 @@ extension PagePropertyType: Codable {
                 String.self,
                 forKey: .url
             )
-            if let value = value {
-                self = .url(URL(string: value))
+            if let value = value,
+               let url = URL(string: value){
+                self = .url(url)
             } else {
                 self = .url(nil)
             }

--- a/Sources/NotionSwift/Models/Request/DatabaseSort.swift
+++ b/Sources/NotionSwift/Models/Request/DatabaseSort.swift
@@ -14,21 +14,21 @@ public struct DatabaseSort {
         case descending
     }
 
-    public let property: String
+    public let property: String?
     public let timestamp: TimestampValue?
     public let direction: DirectionValue?
 }
 
 extension DatabaseSort {
     public static func ascending(
-        property: String,
+        property: String?,
         timestamp: TimestampValue? = nil
     ) -> Self {
         .init(property: property, timestamp: timestamp, direction: .ascending)
     }
 
     public static func descending(
-        property: String,
+        property: String?,
         timestamp: TimestampValue? = nil
     ) -> Self {
         .init(property: property, timestamp: timestamp, direction: .descending)

--- a/Sources/NotionSwift/Models/Request/DatabaseSort.swift
+++ b/Sources/NotionSwift/Models/Request/DatabaseSort.swift
@@ -21,17 +21,29 @@ public struct DatabaseSort {
 
 extension DatabaseSort {
     public static func ascending(
-        property: String?,
+        property: String,
         timestamp: TimestampValue? = nil
     ) -> Self {
         .init(property: property, timestamp: timestamp, direction: .ascending)
     }
 
     public static func descending(
-        property: String?,
+        property: String,
         timestamp: TimestampValue? = nil
     ) -> Self {
         .init(property: property, timestamp: timestamp, direction: .descending)
+    }
+
+    public static func ascending(
+        timestamp: TimestampValue
+    ) -> Self {
+        .init(property: nil, timestamp: timestamp, direction: .ascending)
+    }
+
+    public static func descending(
+        timestamp: TimestampValue
+    ) -> Self {
+        .init(property: nil, timestamp: timestamp, direction: .descending)
     }
 }
 


### PR DESCRIPTION
Hey there, thanks again for your work on this package! 

**URL deserialisation issue fixed**
It is possible to put any text in a Notion URL property, the library was not handling that and there was an error when deserialising. I've changed the code so that the url is nil in such cases.

**Sorting objects by timestamp only**
I had a case where I wanted to sort database pages by timestamp only, that was not possible (I think) without making DatabaseSort.property nullable. Changed that and added methods to use that while still having strong types for other cases.