### PR TITLE
Handled null number value in rollup property

### DIFF
--- a/Sources/NotionSwift/Models/PageProperty.swift
+++ b/Sources/NotionSwift/Models/PageProperty.swift
@@ -105,7 +105,7 @@ extension PagePropertyType {
 
     public enum RollupPropertyValue {
         case array([PagePropertyType])
-        case number(Decimal)
+        case number(Decimal?)
         case date(DateRange?)
         case unknown
     }
@@ -454,7 +454,7 @@ extension PagePropertyType.RollupPropertyValue: Codable {
             let value = try container.decode([PagePropertyType].self, forKey: .array)
             self = .array(value)
         case CodingKeys.number.rawValue:
-            let value = try container.decode(Decimal.self, forKey: .number)
+            let value = try container.decode(Decimal?.self, forKey: .number)
             self = .number(value)
         case CodingKeys.date.rawValue:
             let value = try container.decodeIfPresent(DateRange.self, forKey: .date)

--- a/Tests/NotionSwiftTests/Helpers.swift
+++ b/Tests/NotionSwiftTests/Helpers.swift
@@ -15,6 +15,7 @@ func encodeToJson<T: Encodable>(_ entity: T) throws -> String {
 
 func decodeFromJson<T: Decodable>(_ entity: String) throws -> T {
     let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .formatted(DateFormatter.iso8601Full)
     let data = try decoder.decode(T.self, from: entity.data(using: .utf8)!)
     return data
 }

--- a/Tests/NotionSwiftTests/Models/PageTests.swift
+++ b/Tests/NotionSwiftTests/Models/PageTests.swift
@@ -1,0 +1,75 @@
+//
+//  Created by Michal Zolnieruk on 02/09/2022.
+//
+
+import Foundation
+
+import XCTest
+@testable import NotionSwift
+
+// swiftlint:disable line_length
+final class PageTests: XCTestCase {
+
+    func test_rollupwithnullnumber_deserialization() throws {
+        let json = """
+            {
+              "object": "page",
+              "id": "0556881a-b22c-42f8-a841-e64cdf1507aa",
+              "created_time": "2022-09-02T16:14:00.000Z",
+              "last_edited_time": "2022-09-02T16:14:00.000Z",
+              "created_by": {
+                "object": "user",
+                "id": "25c72bb8-e257-4525-b508-abe1436dc6c1"
+              },
+              "last_edited_by": {
+                "object": "user",
+                "id": "25c72bb8-e257-4525-b508-abe1436dc6c1"
+              },
+              "cover": null,
+              "icon": null,
+              "parent": {
+                "type": "database_id",
+                "database_id": "b33717ea-7c4b-4848-b456-9cb4f9c99441"
+              },
+              "archived": false,
+              "properties": {
+                "Progress": {
+                  "id": "fmwt",
+                  "type": "rollup",
+                  "rollup": {
+                    "type": "number",
+                    "number": null,
+                    "function": "percent_checked"
+                  }
+                },
+                "Name": {
+                  "id": "title",
+                  "type": "title",
+                  "title": [
+                    {
+                      "type": "text",
+                      "text": {
+                        "content": "Test",
+                        "link": null
+                      },
+                      "annotations": {
+                        "bold": false,
+                        "italic": false,
+                        "strikethrough": false,
+                        "underline": false,
+                        "code": false,
+                        "color": "default"
+                      },
+                      "plain_text": "Test",
+                      "href": null
+                    }
+                  ]
+                }
+              },
+              "url": "https://www.notion.so/Test-0556881ab22c42f8a841e64cdf1507aa"
+            }
+            """
+
+        let _ : Page = try decodeFromJson(json)
+    }
+}


### PR DESCRIPTION
I got this deserialisation error:

`valueNotFound(__C.NSDecimal, Swift.DecodingError.Context(codingPath: [CodingKeys(stringValue: "properties", intValue: nil), _JSONKey(stringValue: "Progress", intValue: nil), CodingKeys(stringValue: "rollup", intValue: nil), CodingKeys(stringValue: "number", intValue: nil)], debugDescription: "Expected NSDecimal value but found null instead.", underlyingError: nil))`

when the page retrieved from Notion had this property:

```
"Progress":{
   "id":"fmwt",
   "type":"rollup",
   "rollup":{
      "type":"number",
      "number":null,
      "function":"percent_checked"
   }
}
```

so I've made the number nullable and added a unit test for Page deserialisation. Wasn't sure if the test was needed, let me know if you think it's too much or whether the test name should be more general.