### PR TITLE
Add database entry creation section to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,34 @@ notion.databaseUpdate(databaseId: id, request: request) {
 }
 ```
 
+### Create a database entry
+
+Notion database entries are pages, whose properties conform to the parent database's schema.
+
+```swift
+let databaseId = Database.Identifier("{DATABASE UUIDv4}")
+
+let request = PageCreateRequest(
+    parent: .database(databaseId),
+    properties: [
+        "title": .init(
+            type: .title([
+                .init(string: "Lorem ipsum \(Date())")
+            ])
+        )
+        "Field 10": .init(
+            type: .richText([
+                .init(string: "dolor sit amet")
+            ])
+        )
+    ]
+)
+
+notion.pageCreate(request: request) {
+    print($0)
+}
+```
+
 ### Retrieve a page
 
 Retrieve page properties. 


### PR DESCRIPTION
Had to cross reference the API docs to see if this would work, if someone hasn't worked with notion much before the fact database entries are just pages might not be so obvious.

Depending on if you want to obscure the implementation details of databases, I'd even say it would be handy to have something like `DatabaseEntryCreateRequest` and `notion.databaseEntryCreate` ("entry" might not be the best term both in the proposed readme change and method names). Happy to try and work on a PR for the above if you'd like?