### PR TITLE
Add the `isInline` property to create inline table

### DIFF
--- a/Sources/NotionSwift/Models/Database.swift
+++ b/Sources/NotionSwift/Models/Database.swift
@@ -18,6 +18,7 @@ public struct Database {
     public let lastEditedBy: PartialUser
     public let properties: [PropertyName: DatabaseProperty]
     public let parent: DatabaseParent
+    public let isInline: Bool
 
     public init(
         id: Database.Identifier,
@@ -30,7 +31,8 @@ public struct Database {
         createdBy: PartialUser,
         lastEditedBy: PartialUser,
         properties: [Database.PropertyName: DatabaseProperty],
-        parent: DatabaseParent
+        parent: DatabaseParent,
+        isInline: Bool
     ) {
         self.id = id
         self.url = url
@@ -43,6 +45,7 @@ public struct Database {
         self.lastEditedBy = lastEditedBy
         self.properties = properties
         self.parent = parent
+        self.isInline = isInline
     }
 }
 
@@ -59,6 +62,7 @@ extension Database: Decodable {
         case lastEditedBy = "last_edited_by"
         case properties
         case parent
+        case isInline = "is_inline"
     }
 }
 

--- a/Sources/NotionSwift/Models/Request/DatabaseCreateRequest.swift
+++ b/Sources/NotionSwift/Models/Request/DatabaseCreateRequest.swift
@@ -10,19 +10,22 @@ public struct DatabaseCreateRequest {
     public let cover: CoverFile?
     public let title: [RichText]?
     public let properties: [Database.PropertyName: DatabasePropertyType]
+    public let isInline: Bool?
 
     public init(
         parent: DatabaseParent,
         icon: IconFile?,
         cover: CoverFile?,
         title: [RichText]?,
-        properties: [Database.PropertyName: DatabasePropertyType]
+        properties: [Database.PropertyName: DatabasePropertyType],
+        isInline: Bool? = false
     ) {
         self.parent = parent
         self.icon = icon
         self.cover = cover
         self.title = title
         self.properties = properties
+        self.isInline = isInline
     }
 }
 
@@ -33,6 +36,7 @@ extension DatabaseCreateRequest: Encodable {
         case cover
         case title
         case properties
+        case isInline = "is_inline"
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -42,5 +46,6 @@ extension DatabaseCreateRequest: Encodable {
         try container.encodeIfPresent(cover, forKey: .cover)
         try container.encodeIfPresent(title, forKey: .title)
         try container.encode(properties, forKey: .properties)
+        try container.encode(isInline, forKey: .isInline)
     }
 }


### PR DESCRIPTION
According to the [official document](https://developers.notion.com/reference/database), there is a field called `is_inline` to distinguish whether the database appears in the page as an inline block.
I add this property to the `DatabaseCreateRequest` for users to create an inline table. I set the default value to false so it won't break the code.