### PR TITLE
Accept user's URLSessionConfiguration (for DefaultNetworkClient)

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,20 @@ let notion = NotionClient(accessKeyProvider: StringAccessKeyProvider(accessKey: 
 
 ```
 
+### Tweak networking layer
+
+To tweak things like network timeouts you can provide a custom `URLSessionConfiguration` to `NotionClient`  like below.
+
+```swift
+
+let sessionConfig = URLSessionConfiguration.default
+sessionConfig.timeoutIntervalForRequest = 15
+let client = NotionClient(accessKeyProvider: StringAccessKeyProvider(accessKey: "{NOTION_TOKEN}"), sessionConfiguration: sessionConfig)
+
+```
+
+If that's not enough for your needs, you can implement the `NetworkClient` protocol and provide your implementation to `NotionClient`.
+
 ### List all databases
 
 The `https://api.notion.com/v1/databases` is deprecated. To recommended way to list all databases is to use `https://api.notion.com/v1/search` endpoint. 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ instruction how to obtain `NOTION_TOKEN` please check [Notion Offical Documentat
 
 **Important:** Integrations are granted access to resources (pages and databases) which users have shared with the integration. Resources that are not shared with the integration are not visible by API endpoints. 
 
-### Creating a Notion client.
+### Creating a Notion client
 
 ```swift
 
@@ -41,7 +41,7 @@ let notion = NotionClient(accessKeyProvider: StringAccessKeyProvider(accessKey: 
 
 ```
 
-### Tweak networking layer
+### Tweak network configuration
 
 To tweak things like network timeouts you can provide a custom `URLSessionConfiguration` to `NotionClient`  like below.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ To tweak things like network timeouts you can provide a custom `URLSessionConfig
 
 let sessionConfig = URLSessionConfiguration.default
 sessionConfig.timeoutIntervalForRequest = 15
-let client = NotionClient(accessKeyProvider: StringAccessKeyProvider(accessKey: "{NOTION_TOKEN}"), sessionConfiguration: sessionConfig)
+let notion = NotionClient(accessKeyProvider: StringAccessKeyProvider(accessKey: "{NOTION_TOKEN}"), sessionConfiguration: sessionConfig)
 
 ```
 

--- a/Sources/NotionSwift/Network/NetworkClient.swift
+++ b/Sources/NotionSwift/Network/NetworkClient.swift
@@ -56,14 +56,17 @@ public protocol NetworkClient: AnyObject {
 
 public class DefaultNetworkClient: NetworkClient {
     private let encoder: JSONEncoder
-    private let decoder: JSONDecoder    
+    private let decoder: JSONDecoder
+    private let session: URLSession
 
-    public init() {
+    public init(sessionConfiguration: URLSessionConfiguration) {
         encoder = JSONEncoder()
         encoder.dateEncodingStrategy = .formatted(DateFormatter.iso8601Full)
 
         decoder = JSONDecoder()
         decoder.dateDecodingStrategy = .formatted(DateFormatter.iso8601Full)
+
+        session = .init(configuration: sessionConfiguration)
     }
 
     public func get<R: Decodable>(
@@ -185,7 +188,7 @@ public class DefaultNetworkClient: NetworkClient {
         completed: @escaping (Result<T, NotionClientError>) -> Void
     ) {
         Environment.log.debug("Request: \(request.httpMethod ?? "") \(request.url?.absoluteString ?? "")")
-        let task = URLSession.shared.dataTask(with: request) { data, response, error in
+        let task = session.dataTask(with: request) { data, response, error in
             var completeResult: Result<T, NotionClientError>?
 
             if let error = NetworkClientHelpers.extractError(data: data, response: response, error: error) {

--- a/Sources/NotionSwift/NotionClient.swift
+++ b/Sources/NotionSwift/NotionClient.swift
@@ -13,7 +13,15 @@ public final class NotionClient: NotionClientType {
 
     public init(
         accessKeyProvider: AccessKeyProvider,
-        networkClient: NetworkClient = DefaultNetworkClient()
+        sessionConfiguration: URLSessionConfiguration = .default
+    ) {
+        self.accessKeyProvider = accessKeyProvider
+        self.networkClient = DefaultNetworkClient(sessionConfiguration: sessionConfiguration)
+    }
+
+    public init(
+        accessKeyProvider: AccessKeyProvider,
+        networkClient: NetworkClient
     ) {
         self.accessKeyProvider = accessKeyProvider
         self.networkClient = networkClient


### PR DESCRIPTION
I have a need to set custom (shorter) timeouts for requests, so I added a way to inject a custom `URLSessionConfiguration` to `NotionClient`, which is then passed to `DefaultNetworkClient`. This also means that `URLSession.shared` is no longer used (a custom `URLSession` is created).

I know that one could implement NetworkClient to customise networking calls, but IMO that's too much of a hassle for simple needs.