### PR TITLE
fixed update block  format error

### DIFF
--- a/Sources/NotionSwift/Models/Blocks/UpdateBlock.swift
+++ b/Sources/NotionSwift/Models/Blocks/UpdateBlock.swift
@@ -5,14 +5,13 @@
 import Foundation
 
 public struct UpdateBlock {
-    public let value: BlockType?
-    public let archived: Bool?
-    public let color: BlockColor
 
-    public init(value: BlockType?, archived: Bool? = nil, color: BlockColor = .default) {
-        self.value = value
+    public let type: BlockType
+    public let archived: Bool?
+
+    public init(value: BlockType, archived: Bool? = nil) {
+        self.type = value
         self.archived = archived
-        self.color = color
     }
 }
 
@@ -21,11 +20,9 @@ public struct UpdateBlock {
 extension UpdateBlock: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: Block.CodingKeys.self)
-        if let value = value {
-            try value.encode(to: encoder)
-        }
+        try type.encode(to: encoder)
         try container.encodeIfPresent(archived, forKey: .archived)
-        try container.encode(color, forKey: .color)
     }
 }
+
 


### PR DESCRIPTION
According Notion api doc update block no more need color value，The pre-existing Color field was causing the API to return a formatting error. Upon investigation, it was discovered that the Notion API documentation did not include this field. The error was fixed by removing the field.