### PR TITLE
Property `User.Person.email` should be optional

### DIFF
--- a/Sources/NotionSwift/Models/User.swift
+++ b/Sources/NotionSwift/Models/User.swift
@@ -12,9 +12,9 @@ public struct User {
     }
 
     public struct Person {
-        public let email: String
+        public let email: String?
 
-        public init(email: String) {
+        public init(email: String?) {
             self.email = email
         }
     }


### PR DESCRIPTION
According to [Notion's API reference](https://developers.notion.com/reference/user#people), the property `User.Person.email` 

> only present if an integration has user capabilities that allow access to email addresses

So the property `User.Person.email` should be optional.

---

I noticed this when following error occurred to me

```
NotionSwift.NotionClientError.decodingError(
    Swift.DecodingError.keyNotFound(
        CodingKeys(stringValue: "email", intValue: nil), 
        Swift.DecodingError.Context(
            codingPath: [
                CodingKeys(stringValue: "results", intValue: nil), 
                _JSONKey(stringValue: "Index 6", intValue: 6), 
                CodingKeys(stringValue: "properties", intValue: nil), 
                _JSONKey(stringValue: "Assignee", intValue: nil), 
                CodingKeys(stringValue: "people", intValue: nil), 
                _JSONKey(stringValue: "Index 0", intValue: 0), 
                CodingKeys(stringValue: "person", intValue: nil)
            ], 
            debugDescription: "No value associated with key CodingKeys(stringValue: \"email\", intValue: nil) (\"email\").", 
            underlyingError: nil
        )
    )
)
```

I checked response data from Notion server and it is some thing like this

``` json
// omitted
    "Assignee": {
        "id": "notion%3A%2F%2Ftasks%2Fassign_property",
        "type": "people",
        "people": [
            {
                "object": "user",
                "id": "***",
                "name": "Ivy",
                "avatar_url": null,
                "type": "person",
                "person": {}
            }
        ]
    }
// omitted
```

Apparently for notion integrations that doesn't have permission to access user's email address (such as my notion integration), the `email` property is omitted entirely.