### PR TITLE
feat: add Delete Page api call, rename pageUpdateProperties to pageUpdate 

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,7 +227,7 @@ notion.pageCreate(request: request) {
 let pageId = Page.Identifier("{PAGE UUIDv4}")
 
 // update title property
-let request = PageProperiesUpdateRequest(
+let request = PageUpdateRequest(
     properties: [
         .name("title"): .init(
             type: .title([
@@ -237,7 +237,20 @@ let request = PageProperiesUpdateRequest(
     ]
 )
 
-notion.pageUpdateProperties(pageId: pageId, request: request) {
+notion.pageUpdate(pageId: pageId, request: request) {
+    print($0)
+}
+```
+
+### Delete page 
+
+```swift
+let pageId = Page.Identifier("{PAGE UUIDv4}")
+
+// Archive page (trash a page)
+let request = PageUpdateRequest(archived: true)
+
+notion.pageUpdate(pageId: pageId, request: request) {
     print($0)
 }
 ```

--- a/Sources/NotionSwift/Models/Request/PageUpdateRequest.swift
+++ b/Sources/NotionSwift/Models/Request/PageUpdateRequest.swift
@@ -4,7 +4,7 @@
 
 import Foundation
 
-public struct PageProperiesUpdateRequest {
+public struct PageUpdateRequest {
     public enum Key: Hashable, Equatable  {
         case name(Page.PropertyName)
         case id(PageProperty.Identifier)
@@ -29,7 +29,7 @@ public struct PageProperiesUpdateRequest {
 
 }
 
-extension PageProperiesUpdateRequest: Encodable {
+extension PageUpdateRequest: Encodable {
     enum CodingKeys: String, CodingKey {
         case properties
         case archived
@@ -61,7 +61,7 @@ extension PageProperiesUpdateRequest: Encodable {
     }
 }
 
-extension PageProperiesUpdateRequest.Key: Encodable {
+extension PageUpdateRequest.Key: Encodable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.singleValueContainer()
         switch self {

--- a/Sources/NotionSwift/NotionClient+Pages.swift
+++ b/Sources/NotionSwift/NotionClient+Pages.swift
@@ -31,9 +31,9 @@ import Foundation
         )
     }
 
-    public func pageUpdateProperties(
+    public func pageUpdate(
         pageId: Page.Identifier,
-        request: PageProperiesUpdateRequest,
+        request: PageUpdateRequest,
         completed: @escaping (Result<Page, NotionClientError>) -> Void
     ) {
         networkClient.patch(

--- a/Sources/NotionSwift/NotionClientType+Combine.swift
+++ b/Sources/NotionSwift/NotionClientType+Combine.swift
@@ -96,12 +96,12 @@ extension NotionClientType {
         }
     }
 
-    public func pageUpdateProperties(
+    public func pageUpdate(
         pageId: Page.Identifier,
-        request: PageProperiesUpdateRequest
+        request: PageUpdateRequest
     ) -> AnyPublisher<Page, NotionClientError> {
         convertToPublisher { promise in
-            self.pageUpdateProperties(
+            self.pageUpdate(
                 pageId: pageId,
                 request: request,
                 completed: promise

--- a/Sources/NotionSwift/NotionClientType.swift
+++ b/Sources/NotionSwift/NotionClientType.swift
@@ -67,9 +67,9 @@ public protocol NotionClientType: AnyObject {
         completed: @escaping (Result<Page, NotionClientError>) -> Void
     )
 
-    func pageUpdateProperties(
+    func pageUpdate(
         pageId: Page.Identifier,
-        request: PageProperiesUpdateRequest,
+        request: PageUpdateRequest,
         completed: @escaping (Result<Page, NotionClientError>) -> Void
     )
 


### PR DESCRIPTION
– Add Delete Page readme example (according with[ Trash a page](https://developers.notion.com/reference/archive-a-page) Notion API documentation)
– Refactor `pageUpdateProperties` function to just `pageUpdate` (because this endpoint is used not just for updating properties, but to delete a page, update icon and cover) 