### PR TITLE
Add support for filtering databases using the Status property type

### DIFF
--- a/NotionSwift.podspec
+++ b/NotionSwift.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'NotionSwift'
-  s.version          = '0.8.0'
+  s.version          = '0.9.0'
   s.summary          = 'Unofficial Notion SDK for iOS & macOS.'
   s.homepage         = 'https://github.com/chojnac/NotionSwift'
   s.license          = { :type => 'MIT', :file => 'LICENSE' }

--- a/README.md
+++ b/README.md
@@ -15,14 +15,14 @@ For more details and documentation please check [Notion Developer Portal](https:
 ### CocoaPods
 
 ```ruby
-pod 'NotionSwift', '0.8.0'
+pod 'NotionSwift', '0.9.0'
 ```
 
 ### Swift Package Manager
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/chojnac/NotionSwift.git", .upToNextMajor(from: "0.8.0"))
+    .package(url: "https://github.com/chojnac/NotionSwift.git", .upToNextMajor(from: "0.9.0"))
 ]
 ```
 


### PR DESCRIPTION
Adds additional database property filter support for the [status](https://developers.notion.com/reference/post-database-query-filter#status) property type.

**Example Usage**
```swift
databaseQuery(
    databaseId: databaseId,
    params: .init(filter: .property(name: "Status", type: .status(.equals("Done"))))
)
```

**Example Request**
```
POST /v1/databases/<id>/query HTTP/1.1
Host: api.notion.com
Content-Type: application/json
Accept-Encoding: gzip, deflate, br
User-Agent: notion2markdown (unknown version) CFNetwork/1496.0.7 Darwin/23.5.0
Connection: keep-alive
Accept: */*
Accept-Language: en-US,en;q=0.9
Notion-Version: 2022-06-28
Authorization: Bearer <token>
Content-Length: 64
Pragma: no-cache
Cache-Control: no-cache

{"filter":{"status":{"equals":"Done"},"property":"Status"}}
```