### PR TITLE
Make DatabasePropertyType SelectOption optional

### DIFF
--- a/Sources/NotionSwift/Models/DatabasePropertyType.swift
+++ b/Sources/NotionSwift/Models/DatabasePropertyType.swift
@@ -49,7 +49,7 @@ extension DatabasePropertyType {
     public struct SelectOption {
         public typealias Identifier = EntityIdentifier<SelectOption, UUIDv4>
         public let name: String
-        public let id: Identifier
+        public let id: Identifier?
         public let color: String
 
         public init(


### PR DESCRIPTION
* Aligns better with the actual notion api
* Decoding is working again

Solving: Search Endpoint Decoding Error #56 